### PR TITLE
Ignore cpu temp error

### DIFF
--- a/bin/cpu_monitor.py
+++ b/bin/cpu_monitor.py
@@ -192,11 +192,7 @@ class CPUMonitor():
             retcode = p.returncode
 
             if retcode != 0:
-                diag_level = DiagnosticStatus.ERROR
-                diag_msg = [ 'Core Temperature Error' ]
-                diag_vals = [ KeyValue(key = 'Core Temperature Error', value = str(stderr)),
-                              KeyValue(key = 'Output', value = str(stdout)) ]
-                return diag_vals, diag_msgs, diag_level
+                continue
 
             tmp = stdout.strip()
             if not isinstance(tmp, str):
@@ -217,6 +213,11 @@ class CPUMonitor():
             else:
                 diag_level = max(diag_level, DiagnosticStatus.ERROR) # Error if not numeric value
                 diag_vals.append(KeyValue(key = 'Core %s Temperature' % index, value = tmp))
+
+        if not diag_vals:
+            diag_level = DiagnosticStatus.ERROR
+            diag_msgs = [ 'Core Temperature Error' ]
+            diag_vals = [ KeyValue(key = 'Core Temperature Error', value = 'Cannot Read Core Temperature') ]
 
         return diag_vals, diag_msgs, diag_level
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

cpu温度を読むときにいくつかの利用されているファイルと利用されていないファイルどれが正しいかわからないので全てを読みにいくが、
利用されていないファイルでは温度取得できず、
取得できなかったファイルが一つでもある条件下では、他で読み取れていてもErrorと吐き出してしまっていたので、
全て読んだ後にcpu温度情報が一つも取得できていない場合のみErrorと出すように

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
